### PR TITLE
ToC: Fix JavaScript link

### DIFF
--- a/contents/ToC.md
+++ b/contents/ToC.md
@@ -7,7 +7,7 @@
   * [Java Streams](java/streams-an-introduction.md)
   * [Java Synchronization](java/JavaSynchronization.md)
   * [Java Reflection](java/JavaReflections.md)
-* [JavaScript](javascript/Javascript.md)
+* [JavaScript](javascript/javascript.md)
 * [Python](python/introduction-to-python.md)
 * [Ruby](ruby/Ruby.md)
 * [Swift](swift/welcome-to-swift.md)


### PR DESCRIPTION
fix upper case letter of JavaScript link

Original link was upper case and leads to 404 page:

https://github.com/se-edu/learningresources/blob/master/contents/javascript/Javascript.md