### PR TITLE
ToC.md: Fix link to `machine learning` chapter

### DIFF
--- a/contents/ToC.md
+++ b/contents/ToC.md
@@ -52,7 +52,7 @@
 ## Other Topics
 
 * AI
-  * [Machine Learning] (ai/ml.md)
+  * [Machine Learning](ai/ml.md)
 * [Android](android/IntroToAndroid.md)
 * Architecture
   * [REST](architecture/RESTArchitecturalStyle.md)


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/12574756/39111586-3d5cb914-4708-11e8-94b0-24bb72aef311.png)
The chapter was not linked due to extra space