### PR TITLE
Fix broken links on project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ This repository is a collection of Software Engineering learning resources.
 
 ---
 
-[Guidelines for Contributors](GuidelinesForContributors.md) | [Contact](Contact.md) | License: MIT
+[Guidelines for Contributors](https://se-education.org/learningresources/contributing.html) | [Contact](https://se-education.org/learningresources/about.html) | License: MIT
 
 </div>


### PR DESCRIPTION
The current links on the project README is broken. I've updated the links to point to the relevant pages on the site instead.