### PR TITLE
#138 table of contents (Python/Ruby/Rust/Scala/Swift)

### DIFF
--- a/contents/python/introduction-to-python.md
+++ b/contents/python/introduction-to-python.md
@@ -15,6 +15,21 @@
 
 Authors: [Samson Tan Min Rong](https://www.linkedin.com/in/samsontmr/), [Phang Chun Rong](https://www.github.com/Crphang)
 
+<box id="article-toc">
+
+* [An Introduction to Python‎](#an-introduction-to-python)
+  * [Getting started with Python‎](#getting-started-with-python)
+  * [Python 2 vs Python 3‎](#python-2-vs-python-3)
+  * [Virtual Environment‎](#virtual-environment)
+  * [Common Data Structures‎](#common-data-structures)
+  * [Indexing and Slicing‎](#indexing-and-slicing)
+  * [Object Oriented Programming in Python‎](#object-oriented-programming-in-python)
+  * [Functional Programming‎](#functional-programming)
+  * [Python for Data Science‎](#python-for-data-science)
+    * [Tutorials‎](#tutorials)
+  * [Gotchas‎](#gotchas)
+</box>
+
 Python is a simple yet powerful and versatile language. Conceived in the late 80s, it is now widely used across many fields of computer science and software engineering. While not as speedy as compiled languages like C or Java, Python's emphasis on readability, and resulting ease of maintenance, often outweighs the advantages conferred by compiled languages. This especially true in applications where execution speed is non-critical.
 
 ## Getting started with Python

--- a/contents/python/introduction-to-python.md
+++ b/contents/python/introduction-to-python.md
@@ -17,17 +17,16 @@ Authors: [Samson Tan Min Rong](https://www.linkedin.com/in/samsontmr/), [Phang C
 
 <box id="article-toc">
 
-* [An Introduction to Python‎](#an-introduction-to-python)
-  * [Getting started with Python‎](#getting-started-with-python)
-  * [Python 2 vs Python 3‎](#python-2-vs-python-3)
-  * [Virtual Environment‎](#virtual-environment)
-  * [Common Data Structures‎](#common-data-structures)
-  * [Indexing and Slicing‎](#indexing-and-slicing)
-  * [Object Oriented Programming in Python‎](#object-oriented-programming-in-python)
-  * [Functional Programming‎](#functional-programming)
-  * [Python for Data Science‎](#python-for-data-science)
-    * [Tutorials‎](#tutorials)
-  * [Gotchas‎](#gotchas)
+* [Getting started with Python‎](#getting-started-with-python)
+* [Python 2 vs Python 3‎](#python-2-vs-python-3)
+* [Virtual Environment‎](#virtual-environment)
+* [Common Data Structures‎](#common-data-structures)
+* [Indexing and Slicing‎](#indexing-and-slicing)
+* [Object Oriented Programming in Python‎](#object-oriented-programming-in-python)
+* [Functional Programming‎](#functional-programming)
+* [Python for Data Science‎](#python-for-data-science)
+  * [Tutorials‎](#tutorials)
+* [Gotchas‎](#gotchas)
 </box>
 
 Python is a simple yet powerful and versatile language. Conceived in the late 80s, it is now widely used across many fields of computer science and software engineering. While not as speedy as compiled languages like C or Java, Python's emphasis on readability, and resulting ease of maintenance, often outweighs the advantages conferred by compiled languages. This especially true in applications where execution speed is non-critical.

--- a/contents/ruby/Ruby.md
+++ b/contents/ruby/Ruby.md
@@ -15,6 +15,19 @@
 
 Authors: [Wilson Kurniawan](https://github.com/wkurniawan07)
 
+<box id="article-toc">
+
+* [Introduction to Ruby‎](#introduction-to-ruby)
+  * [Ruby Overview‎](#ruby-overview)
+  * [Getting Started‎](#getting-started)
+    * [Everything is an object‎](#everything-is-an-object)
+    * [Readability is king‎](#readability-is-king)
+    * [Functional programming is encouraged‎](#functional-programming-is-encouraged)
+    * [Object-oriented programming is possible, too‎](#object-oriented-programming-is-possible-too)
+  * [Advanced Topics‎](#advanced-topics)
+  * [Ruby Frameworks and DevOps‎](#ruby-frameworks-and-devops)
+</box>
+
 ## Ruby Overview
 
 **Ruby** is a **dynamic**, **reflective**, **object-oriented**, **general-purpose** programming-language, designed and developed by Yukihiro "Matz" Matsumoto in 1990s.

--- a/contents/ruby/Ruby.md
+++ b/contents/ruby/Ruby.md
@@ -17,15 +17,14 @@ Authors: [Wilson Kurniawan](https://github.com/wkurniawan07)
 
 <box id="article-toc">
 
-* [Introduction to Ruby‎](#introduction-to-ruby)
-  * [Ruby Overview‎](#ruby-overview)
-  * [Getting Started‎](#getting-started)
-    * [Everything is an object‎](#everything-is-an-object)
-    * [Readability is king‎](#readability-is-king)
-    * [Functional programming is encouraged‎](#functional-programming-is-encouraged)
-    * [Object-oriented programming is possible, too‎](#object-oriented-programming-is-possible-too)
-  * [Advanced Topics‎](#advanced-topics)
-  * [Ruby Frameworks and DevOps‎](#ruby-frameworks-and-devops)
+* [Ruby Overview‎](#ruby-overview)
+* [Getting Started‎](#getting-started)
+  * [Everything is an object‎](#everything-is-an-object)
+  * [Readability is king‎](#readability-is-king)
+  * [Functional programming is encouraged‎](#functional-programming-is-encouraged)
+  * [Object-oriented programming is possible, too‎](#object-oriented-programming-is-possible-too)
+* [Advanced Topics‎](#advanced-topics)
+* [Ruby Frameworks and DevOps‎](#ruby-frameworks-and-devops)
 </box>
 
 ## Ruby Overview

--- a/contents/rust/Rust.md
+++ b/contents/rust/Rust.md
@@ -17,14 +17,13 @@ Author(s): [Tan Li Hao](https://github.com/LiHaoTan)
 
 <box id="article-toc">
 
-* [Rust‎](#rust)
-    * [Why Rust‎](#why-rust)
-        * [Safety‎](#safety)
-        * [Better support for concurrency‎](#better-support-for-concurrency)
-        * [Practicality‎](#practicality)
-    * [How to learn Rust‎](#how-to-learn-rust)
-        * [Resources to learn Rust‎](#resources-to-learn-rust)
-    * [Why not Rust‎](#why-not-rust)
+* [Why Rust‎](#why-rust)
+    * [Safety‎](#safety)
+    * [Better support for concurrency‎](#better-support-for-concurrency)
+    * [Practicality‎](#practicality)
+* [How to learn Rust‎](#how-to-learn-rust)
+    * [Resources to learn Rust‎](#resources-to-learn-rust)
+* [Why not Rust‎](#why-not-rust)
 </box>
 
 ## Why Rust

--- a/contents/rust/Rust.md
+++ b/contents/rust/Rust.md
@@ -15,6 +15,18 @@
 
 Author(s): [Tan Li Hao](https://github.com/LiHaoTan)
 
+<box id="article-toc">
+
+* [Rust‎](#rust)
+    * [Why Rust‎](#why-rust)
+        * [Safety‎](#safety)
+        * [Better support for concurrency‎](#better-support-for-concurrency)
+        * [Practicality‎](#practicality)
+    * [How to learn Rust‎](#how-to-learn-rust)
+        * [Resources to learn Rust‎](#resources-to-learn-rust)
+    * [Why not Rust‎](#why-not-rust)
+</box>
+
 ## Why Rust
 Rust is a multi-paradigm (e.g. functional and imperative) systems language, but as it is relatively new the benefits of learning or using the language is not very clear. In any case, it is important to know the merits of a language so we know when to use them.
 

--- a/contents/scala/Scala.md
+++ b/contents/scala/Scala.md
@@ -19,15 +19,14 @@ Reviewers: [Jiang Chunhui](https://github.com/Adoby7), [Wang Junming](https://gi
 
 <box id="article-toc">
 
-* [Introduction to Scala‎](#introduction-to-scala)
-  * [Overview‎](#overview)
-  * [Noteworthy Scala Features‎](#noteworthy-scala-features)
-    * [Type Inference‎](#type-inference)
-    * [Operator Overloading‎](#operator-overloading)
-    * [Mixins, Traits‎](#mixins-traits)
-    * [Type Enrichment‎](#type-enrichment)
-    * [Pattern Matching‎](#pattern-matching)
-  * [Getting Started‎](#getting-started)
+* [Overview‎](#overview)
+* [Noteworthy Scala Features‎](#noteworthy-scala-features)
+  * [Type Inference‎](#type-inference)
+  * [Operator Overloading‎](#operator-overloading)
+  * [Mixins, Traits‎](#mixins-traits)
+  * [Type Enrichment‎](#type-enrichment)
+  * [Pattern Matching‎](#pattern-matching)
+* [Getting Started‎](#getting-started)
 </box>
 
 ## Overview

--- a/contents/scala/Scala.md
+++ b/contents/scala/Scala.md
@@ -17,6 +17,19 @@
 
 Reviewers: [Jiang Chunhui](https://github.com/Adoby7), [Wang Junming](https://github.com/junming403)
 
+<box id="article-toc">
+
+* [Introduction to Scala‎](#introduction-to-scala)
+  * [Overview‎](#overview)
+  * [Noteworthy Scala Features‎](#noteworthy-scala-features)
+    * [Type Inference‎](#type-inference)
+    * [Operator Overloading‎](#operator-overloading)
+    * [Mixins, Traits‎](#mixins-traits)
+    * [Type Enrichment‎](#type-enrichment)
+    * [Pattern Matching‎](#pattern-matching)
+  * [Getting Started‎](#getting-started)
+</box>
+
 ## Overview
 
 > Scala combines object-oriented and functional programming in one concise, high-level language. Scala's static types help avoid bugs in complex applications, and its JVM and JavaScript runtimes let you build high-performance systems with easy access to huge ecosystems of libraries. -- [Scala Website](https://www.scala-lang.org/)

--- a/contents/swift/welcome-to-swift.md
+++ b/contents/swift/welcome-to-swift.md
@@ -17,6 +17,22 @@
 
 Reviewers: [Aaron Chong](https://github.com/acjh), [Bryan Lew](https://github.com/blewjy), [Dickson Tan](https://github.com/Neurrone), [Rachael Sim](https://github.com/rachx), [Rahul Rajesh](https://github.com/rrtheonlyone), [Sam Yong](https://github.com/mauris), [Tan Wang Leng](https://github.com/yamgent), [Vivek Lakshmanan](https://github.com/vivekscl), [Wang Junming](https://github.com/junming403), [Xiao Pu](https://github.com/xpdavid)
 
+<box id="article-toc">
+
+* [Swift‎](#swift)
+    * [Swift Overview‎](#swift-overview)
+    * [Noteworthy Swift Features‎](#noteworthy-swift-features)
+        * [Type Inference‎](#type-inference)
+        * [Optionals‎](#optionals)
+        * [Defer Statements‎](#defer-statements)
+        * [Data Types‎](#data-types)
+        * [Protocol Oriented Programming‎](#protocol-oriented-programming)
+        * [Extensions‎](#extensions)
+        * [Automatic Reference Counting‎](#automatic-reference-counting)
+        * [CocoaPods‎](#cocoapods)
+    * [How to Get Started‎](#how-to-get-started)
+</box>
+
 ## Swift Overview
 
 **Swift is the main programming language used for iOS programming.** Introduced in 2014 by Apple, Swift has more concise and more expressive syntax compared to its predecessor language [Objective-C](). Unlike most other software by Apple, Swift is [open source](https://github.com/apple/swift).

--- a/contents/swift/welcome-to-swift.md
+++ b/contents/swift/welcome-to-swift.md
@@ -19,18 +19,17 @@ Reviewers: [Aaron Chong](https://github.com/acjh), [Bryan Lew](https://github.co
 
 <box id="article-toc">
 
-* [Swift‎](#swift)
-    * [Swift Overview‎](#swift-overview)
-    * [Noteworthy Swift Features‎](#noteworthy-swift-features)
-        * [Type Inference‎](#type-inference)
-        * [Optionals‎](#optionals)
-        * [Defer Statements‎](#defer-statements)
-        * [Data Types‎](#data-types)
-        * [Protocol Oriented Programming‎](#protocol-oriented-programming)
-        * [Extensions‎](#extensions)
-        * [Automatic Reference Counting‎](#automatic-reference-counting)
-        * [CocoaPods‎](#cocoapods)
-    * [How to Get Started‎](#how-to-get-started)
+* [Swift Overview‎](#swift-overview)
+* [Noteworthy Swift Features‎](#noteworthy-swift-features)
+    * [Type Inference‎](#type-inference)
+    * [Optionals‎](#optionals)
+    * [Defer Statements‎](#defer-statements)
+    * [Data Types‎](#data-types)
+    * [Protocol Oriented Programming‎](#protocol-oriented-programming)
+    * [Extensions‎](#extensions)
+    * [Automatic Reference Counting‎](#automatic-reference-counting)
+    * [CocoaPods‎](#cocoapods)
+* [How to Get Started‎](#how-to-get-started)
 </box>
 
 ## Swift Overview

--- a/css/main.css
+++ b/css/main.css
@@ -27,3 +27,14 @@ mark {
 .indented-level3 {
     padding-left: 60px;
 }
+
+/* Responsive table of contents (toc) */
+
+/* Hides toc on screen widths smaller than 1300px */
+/* page-nav appears on screens 1300px wide and above */
+@media screen and (min-width: 1299.98px) {
+    #article-toc {
+        display: none;
+        border: none;
+    }
+}


### PR DESCRIPTION
Adds table of contents (toc) to articles without one and hides them except for mobile and print view as discussed in #138 . 

This PR affects the below chapters under `Programming Languages`. Kindly use the below checklist for reviewing.

Items to test for each chapter:
- [ ] Web view (Expected: in-article toc absent)
- [ ] Mobile view (Expected: in-article toc present and **links clickable**, right nav panel absent)
- [ ] Print view (Expected: in-article toc present, left and right nav panels absent)

Chapters:
- [ ] Python
- [ ] Ruby
- [ ] Rust
- [ ] Scala
- [ ] Swift


Devtools shortcuts
Firefox:
<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>M</kbd>

Chrome:
<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd>